### PR TITLE
New: Add latest memgraph-platform version with Dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,3 @@
-FROM golang:1.19-alpine AS builder
-ENV CGO_ENABLED=0
-WORKDIR /backend
-COPY backend/go.* .
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    go mod download
-COPY backend/. .
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    go build -trimpath -ldflags="-s -w" -o bin/service
-
-FROM --platform=$BUILDPLATFORM node:18.12-alpine3.16 AS client-builder
-WORKDIR /ui
-# cache packages in layer
-COPY ui/package.json /ui/package.json
-COPY ui/package-lock.json /ui/package-lock.json
-RUN --mount=type=cache,target=/usr/src/app/.npm \
-    npm set cache /usr/src/app/.npm && \
-    npm ci
-# install
-COPY ui /ui
-RUN npm run build
-
 FROM alpine
 LABEL org.opencontainers.image.title="Memgraph" \
     org.opencontainers.image.description="Memgraph Extension for Docker Desktop" \
@@ -34,15 +10,11 @@ LABEL org.opencontainers.image.title="Memgraph" \
     com.docker.desktop.extension.icon="https://raw.githubusercontent.com/collabnix/memgraph-docker-extension/main/memgraph.svg" \
     com.docker.extension.detailed-description="Memgraph is a high-performance, in-memory graph database that provides fast and scalable data storage and querying capabilities for graph data. Memgraph is a streaming graph application platform that helps you wrangle your streaming data, build sophisticated models you can query in real-time, and develop applications you never thought possible within a couple of days, not months. With Memgraph Docker Extension, now you can setup Memgraph platform in no seconds." \
     com.docker.extension.publisher-url='[{"title":"GitHub", "url":"https://github.com/collabnix/memgraph-docker-extension/"}]' \
-    com.docker.extension.additional-urls='[{"title":"GitHub","url":"https://https://github.com/collabnix/memgraph-docker-extension/"}]' \
+    com.docker.extension.additional-urls='[{"title":"GitHub","url":"https://github.com/collabnix/memgraph-docker-extension/"}]' \
     com.docker.extension.changelog=""
 
-
-
-COPY --from=builder /backend/bin/service /
 COPY docker-compose.yaml .
 COPY metadata.json .
 COPY docker.svg .
 COPY memgraph.svg .
-COPY --from=client-builder /ui/build ui
-CMD /service -socket /run/guest-services/backend.sock
+COPY ui ui

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE?=ajeetraina/memgraph-docker-extension
-TAG?=1.0.0
+TAG?=1.1.0
 
 BUILDER=buildx-multi-arch
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you're in hurry, [click here](https://open.docker.com/extensions/marketplace?
 ### Install the Extension
 
 ```
- docker extension install ajeetraina/memgraph-docker-extension:latest
+ make install-extension
 ```
 
 ### Accessing the Extension

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   memgraph-platform:
-    image: "memgraph/memgraph-platform:2.6.5-memgraph2.5.2-lab2.4.0-mage1.6"
+    image: "memgraph/memgraph-platform:2.6.6-memgraph2.6.0-lab2.5.0-mage1.6.1"
     ports:
       - "7687:7687"
       - "3000:3000"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   memgraph-platform:
-    image: "memgraph/memgraph-platform"
+    image: "memgraph/memgraph-platform:2.6.5-memgraph2.5.2-lab2.4.0-mage1.6"
     ports:
       - "7687:7687"
       - "3000:3000"
@@ -10,7 +10,7 @@ services:
       - mg_log:/var/log/memgraph
       - mg_etc:/etc/memgraph
     environment:
-      - MEMGRAPH="--log-level=TRACE"
+      - MEMGRAPH="--log-level=INFO"
     entrypoint: ["/usr/bin/supervisord"]
     networks:
       - memnet

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "vm": {
     "composefile": "docker-compose.yaml",
     "exposes": {
-      "socket": "backend.sock"
+      "socket": "extension-memgraph-docker-extension.sock"
     }
   },
   "ui": {
@@ -12,7 +12,7 @@
       "src": "index.html",
       "root": "ui",
       "backend": {
-        "socket": "backend.sock"
+        "socket": "extension-memgraph-docker-extension.sock"
       }
     }
   }


### PR DESCRIPTION
it contains the following updates:

* Use the latest `memgraph-platform` image
* Setting logs to `INFO`
* Use default static `index.html` as a proxy to Memgraph Lab listening on `:3000`
